### PR TITLE
feat: reposition input

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -2,6 +2,8 @@ import React, { useContext } from 'react';
 import styled from 'styled-components';
 import SearchContext from '../contexts/SearchContext';
 import { useNavigate } from 'react-router-dom';
+import SearchBarFilter from './SearchBarFilter';
+import withConditionalWrapper from '../utils/withConditionalWrapper';
 
 const SytledSearchBarContainer = styled.div`
   display: flex;
@@ -20,7 +22,23 @@ const StyledSearchBarList = styled.ul`
   height: 80px;
 `;
 
-const StyledSearchBarItem = styled.button`
+const StyledSearchBarItem = styled.span`
+  border-right: 1px solid #c2c2c2;
+  flex-grow: 1;
+
+  &:first-child {
+    border-top-left-radius: 50px;
+    border-bottom-left-radius: 50px;
+  }
+
+  &:last-child {
+    border-right: none;
+    border-top-right-radius: 50px;
+    border-bottom-right-radius: 50px;
+  }
+`;
+
+const StyledSearchBarButton = styled.button`
   border-right: 1px solid #c2c2c2;
   flex-grow: 1;
 
@@ -40,8 +58,40 @@ const StyledMainText = styled.div`
   font-weight: 700;
 `;
 
+enum SearchKey {
+  NAME = 'name',
+  DATE = 'date',
+  PLACE = 'place',
+  OFFICE = 'office',
+}
+
+const searchItems = [
+  {
+    key: SearchKey.NAME,
+    mainText: '분실제품명',
+    placeholder: '잃어버린 물건의 이름은 무엇인가요?',
+  },
+  {
+    key: SearchKey.DATE,
+    mainText: '분실날짜',
+    placeholder: '언제 잃어버리셨나요?',
+  },
+
+  {
+    key: SearchKey.PLACE,
+    mainText: '분실지역',
+    placeholder: '어디서 잃어버리셨나요?',
+  },
+  {
+    key: SearchKey.OFFICE,
+    mainText: '관할구청',
+    placeholder: '어디서 보관하고 있을까요?',
+  },
+];
+
 export default function SearchBar() {
-  const { lostItem, setTurnedOnInput } = useContext(SearchContext)!;
+  const { lostItem, turnedOnInput, setTurnedOnInput } =
+    useContext(SearchContext)!;
   const navigate = useNavigate();
 
   const navigateToLost = () => {
@@ -59,40 +109,38 @@ export default function SearchBar() {
     setTurnedOnInput(option);
   };
 
+  const SearchBarContent = searchItems.map((item) => {
+    const Child = (
+      <span>
+        <StyledMainText>{item.mainText}</StyledMainText>
+        {turnedOnInput === item.key ? (
+          <SearchBarFilter />
+        ) : (
+          lostItem[item.key] || <div>{item.placeholder}</div>
+        )}
+      </span>
+    );
+
+    return withConditionalWrapper(
+      StyledSearchBarItem,
+      StyledSearchBarButton,
+      Child,
+      item.key === turnedOnInput,
+      item.key === turnedOnInput
+        ? {}
+        : {
+            key: item.key,
+            type: 'button',
+            onClick: () => handleOptionButtonClick(item.key),
+          },
+    );
+  });
+
   return (
     <SytledSearchBarContainer>
       <StyledSearchBarList>
-        <StyledSearchBarItem
-          type="button"
-          onClick={() => handleOptionButtonClick('name')}
-        >
-          <span>
-            <StyledMainText>분실제품명</StyledMainText>
-            {lostItem.name || <div>잃어버린 물건의 이름은 무엇인가요?</div>}
-          </span>
-        </StyledSearchBarItem>
-        <StyledSearchBarItem
-          type="button"
-          onClick={() => handleOptionButtonClick('date')}
-        >
-          <StyledMainText>분실날짜</StyledMainText>
-          {lostItem.date || <div>언제 잃어버리셨나요?</div>}
-        </StyledSearchBarItem>
-        <StyledSearchBarItem
-          type="button"
-          onClick={() => handleOptionButtonClick('place')}
-        >
-          <StyledMainText>분실지역</StyledMainText>
-          {lostItem.place || <div>어디서 잃어버리셨나요?</div>}
-        </StyledSearchBarItem>
-        <StyledSearchBarItem
-          type="button"
-          onClick={() => handleOptionButtonClick('office')}
-        >
-          <StyledMainText>관할구청</StyledMainText>
-          {lostItem.office || <div>어디서 보관하고 있을까요?</div>}
-        </StyledSearchBarItem>
-        <StyledSearchBarItem type="button" onClick={navigateToLost}>
+        {SearchBarContent}
+        <StyledSearchBarButton type="button" onClick={navigateToLost}>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             height="24"
@@ -101,7 +149,7 @@ export default function SearchBar() {
           >
             <path d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z" />
           </svg>
-        </StyledSearchBarItem>
+        </StyledSearchBarButton>
       </StyledSearchBarList>
     </SytledSearchBarContainer>
   );

--- a/src/components/SearchBarFilter.tsx
+++ b/src/components/SearchBarFilter.tsx
@@ -66,7 +66,7 @@ export default function SearchBarFilter() {
           />
         </LocalizationProvider>
         <button type="button" onClick={handleFilterButtonClick}>
-          클릭
+          ✅
         </button>
       </StyledSearchBarFilterContainer>
     );
@@ -84,7 +84,7 @@ export default function SearchBarFilter() {
             onChange={handleInputChange}
           />
           <button type="button" onClick={handleFilterButtonClick}>
-            클릭
+            ✅
           </button>
         </div>
       )}

--- a/src/pages/Found.tsx
+++ b/src/pages/Found.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import CardView from '../components/CardView';
 import CardViewSkeleton from '../components/CardViewSkeleton';
-import { FoundProps } from '../types/Foundprops';
+import { FoundProps } from '../types/FoundProps';
 
 // TODO: 무한 스크롤? 페이지네이션? 구현
 const Found = () => {

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import SearchBar from '../components/SearchBar';
 import SearchProvider from '../providers/SearchProvider';
-import SearchBarFilter from '../components/SearchBarFilter';
 
 const StyledContainer = styled.div`
   height: 100vh;
@@ -38,7 +37,6 @@ export default function Search() {
       </StyledHeader>
       <SearchProvider>
         <SearchBar />
-        <SearchBarFilter />
       </SearchProvider>
     </StyledContainer>
   );

--- a/src/utils/withConditionalWrapper.tsx
+++ b/src/utils/withConditionalWrapper.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode } from 'react';
+
+interface WrapperProps {
+  children: ReactNode;
+}
+
+type WithConditionalWrapperType = (
+  WrapperComponent: React.ComponentType<WrapperProps>,
+  WrapperComponent2: React.ComponentType<WrapperProps>,
+  children: ReactNode,
+  condition: boolean,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  props: any,
+) => ReactNode;
+
+const withConditionalWrapper: WithConditionalWrapperType = (
+  WrapperComponent,
+  WrapperComponent2,
+  children,
+  condition,
+  props,
+) => {
+  if (condition) {
+    console.log(`${Date()}, item goes`);
+    return <WrapperComponent {...props}>{children}</WrapperComponent>;
+  }
+  console.log('button goes');
+  return <WrapperComponent2 {...props}>{children}</WrapperComponent2>;
+};
+
+export default withConditionalWrapper;


### PR DESCRIPTION
구현 내용
1. `withConditionalWrapper`를 사용하여 클릭 되었을 때 `SearchBarItem`이 클릭되었을 때 button으로 바뀌고, 입력을 모두 받은 뒤에 span tag로 바꾸는 부분을 구현하였습니다.
2. SearchBarItem들을 `Array.map()`함수로 표현하여 렌더링하여 유지보수성과 가독성을 높였습니다.

보충할 점
1. input 입력하는 칸의 스타일링이 부족합니다.