### PR TITLE
fix: detail page endpoint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import './App.css';
 import Router from './Router';
 import GlobalStyle from './styles/GlobalStyle';
+import IsLostProvider from './providers/IsLostProvider';
 
 function App() {
   return (
     <div>
       <GlobalStyle />
-      <Router />
+      <IsLostProvider>
+        <Router />
+      </IsLostProvider>
     </div>
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -113,10 +113,10 @@ export default function SearchBar({ width }: SearchBarProps) {
       isLost,
     } = lostItem;
     const entries = Object.entries({ item, date, location_detail, office });
-    const filteredEntries = entries.filter(([value]) => value !== null) as [
-      string,
-      string,
-    ][];
+    const filteredEntries = entries.filter(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ([_, value]) => value !== null && value !== 'null',
+    ) as [string, string][];
     const queryString = new URLSearchParams(filteredEntries).toString();
     if (isLost) {
       navigate(`/lost?${queryString}`);

--- a/src/contexts/IsLostContext.ts
+++ b/src/contexts/IsLostContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+import { IsLostContextType } from '../providers/IsLostProvider';
+
+const IsLostContext = createContext<IsLostContextType | null>(null);
+export default IsLostContext;

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import axios from 'axios';
 import styled from 'styled-components';
+import IsLostContext from '../contexts/IsLostContext';
 
 interface DetailProps {
   item: string;
@@ -15,13 +16,14 @@ const Detail = () => {
   const params = new URLSearchParams(location.search);
   const atc_id = params.get('atc_id');
   console.log('id', atc_id);
+  const { isLost } = useContext(IsLostContext)!;
 
   const [detail, setDetail] = useState<DetailProps>();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get('/lost', {
+        const response = await axios.get(isLost ? '/lost' : '/found', {
           baseURL: process.env.REACT_APP_API_URL,
           params: {
             atc_id,

--- a/src/pages/Found.tsx
+++ b/src/pages/Found.tsx
@@ -1,13 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import axios from 'axios';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import CardView from '../components/CardView';
 import CardViewSkeleton from '../components/CardViewSkeleton';
 import { FoundProps } from '../types/FoundProps';
+import IsLostContext from '../contexts/IsLostContext';
 
 // TODO: 무한 스크롤? 페이지네이션? 구현
 const Found = () => {
+  const { setIsLost } = useContext(IsLostContext)!;
+
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(true);
   const [cardDatas, setCardDatas] = useState([]);
@@ -58,6 +61,7 @@ const Found = () => {
 
   const onClick = (id: string) => {
     console.log(id);
+    setIsLost(false);
     navigate(`/detail?atc_id=${id}`);
   };
 

--- a/src/pages/Lost.tsx
+++ b/src/pages/Lost.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import axios from 'axios';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
@@ -6,12 +6,14 @@ import CardView from '../components/CardView';
 import CardViewSkeleton from '../components/CardViewSkeleton';
 import { LostProps } from '../types/LostProps';
 import { filteredItem } from '../types/FilteredItem';
+import IsLostContext from '../contexts/IsLostContext';
 
 // TODO: 무한 스크롤? 페이지네이션? 구현
 const Lost = () => {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(true);
   const [cardDatas, setCardDatas] = useState([]);
+  const { setIsLost } = useContext(IsLostContext)!;
 
   const params = new URLSearchParams(location.search);
   const item = params.get('item');
@@ -21,13 +23,19 @@ const Lost = () => {
   const office = params.get('office');
 
   useEffect(() => {
+    console.log(item, typeof item);
+    console.log(date, typeof date);
+    console.log(location_detail, typeof location_detail);
+    console.log(location_city, typeof location_city);
+    console.log(office, typeof office);
+
     const fetchData = async () => {
       try {
         const response = await axios.get('/lost', {
           baseURL: process.env.REACT_APP_API_URL,
           params: {
-            date,
             item,
+            date,
             location_detail,
             location_city,
             office,
@@ -58,6 +66,7 @@ const Lost = () => {
 
   const onClick = (id: string) => {
     console.log(id);
+    setIsLost(true);
     navigate(`/detail?atc_id=${id}`);
   };
 

--- a/src/providers/IsLostProvider.tsx
+++ b/src/providers/IsLostProvider.tsx
@@ -1,0 +1,21 @@
+import React, { ReactNode, useState } from 'react';
+import IsLostContext from '../contexts/IsLostContext';
+
+interface IsLostProviderProps {
+  children: ReactNode;
+}
+
+export interface IsLostContextType {
+  isLost: boolean;
+  setIsLost: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function IsLostProvider({ children }: IsLostProviderProps) {
+  const [isLost, setIsLost] = useState(true);
+
+  return (
+    <IsLostContext.Provider value={{ isLost, setIsLost }}>
+      {children}
+    </IsLostContext.Provider>
+  );
+}


### PR DESCRIPTION
detail page가 분실물 페이지로부터 들어왔을 경우에는 `/lost` url로 fetch를 해야하고, '/found' url로 fetch를 해서 물건을 받아와야하므로 전역 context를 만들고 페이지에 들어올 때 상태를 유지할 수 있게 변경했습니다. 